### PR TITLE
feat(register): add repeat password validation and tests

### DIFF
--- a/fixtures/user.fixture.ts
+++ b/fixtures/user.fixture.ts
@@ -1,5 +1,5 @@
 import { test as baseTest } from '@playwright/test';
-import { getExistingUser, getInvalidStaticUser, getStaticUser, getUniqueUser } from '@utils/data/generators/user.generator';
+import { getExistingUser, getInvalidEmailStaticUser, getStaticUser, getUniqueUser, getInvalidRepeatPasswordStaticUser } from '@utils/data/generators/user.generator';
 import { User } from '@models/user.model';
 import { deleteUserByEmail } from '@utils/api/user.api';
 
@@ -9,7 +9,8 @@ interface UserFixture {
 
 interface UserHelpers {
     getStaticUser: () => User;
-    getInvalidStaticUser: () => User;
+    getInvalidEmailStaticUser: () => User;
+    getInvalidRepeatPasswordStaticUser: () => User;
     getExistingUser: () => User;
     getUniqueUser: () => User;
     getUserWithTrack: (getUserFunc: () => User) => User;
@@ -22,7 +23,8 @@ export function registerUserFixture(test: typeof baseTest) {
             const userHelpers: UserHelpers = {
                 users: [],
                 getStaticUser,
-                getInvalidStaticUser,
+                getInvalidEmailStaticUser,
+                getInvalidRepeatPasswordStaticUser,
                 getExistingUser,
                 getUniqueUser,
                 getUserWithTrack: (getUserFunc: () => User) => {

--- a/models/user.model.ts
+++ b/models/user.model.ts
@@ -1,4 +1,5 @@
 export interface User {
     email: string;
     password: string;
+    repeatPassword?: string;
 }

--- a/pages/register.page.ts
+++ b/pages/register.page.ts
@@ -17,7 +17,7 @@ export class RegisterPage {
         return this.page.getByRole('textbox', { name: 'Field for the password' });
     }
 
-    private get confirmPasswordInput(): Locator {
+    private get repeatPasswordInput(): Locator {
         return this.page.getByRole('textbox', { name: 'Field to confirm the password' });
     }
 
@@ -45,6 +45,10 @@ export class RegisterPage {
         return this.page.getByText('Email must be unique');
     }
 
+    private get repeatPasswordError(): Locator {
+        return this.page.getByText('Пароли не совпадают');
+    }
+
     constructor(page: Page) {
         this.page = page;
     }
@@ -60,7 +64,7 @@ export class RegisterPage {
     private async fillForm(user: User) {
         await this.emailInput.fill(user.email);
         await this.passwordInput.fill(user.password);
-        await this.confirmPasswordInput.fill(user.password);
+        await this.repeatPasswordInput.fill(user.repeatPassword ? user.repeatPassword : user.password);
         await this.secretQuestionSelect.click();
         await this.secretQuestionOption.click();
         await this.secretAnswerInput.fill('Test Answer');
@@ -85,6 +89,12 @@ export class RegisterPage {
         return response;
     }
 
+    async registerFillFormOnly(user: User): Promise<void> {
+        await this.go();
+        await this.checkHeadText()
+        await this.fillForm(user);
+    }
+
     async checkRegisterSuccess(response: Promise<Response>) {
         expect((await response).ok()).toBe(true);
 
@@ -104,5 +114,10 @@ export class RegisterPage {
     async checkRegisterInvalidEmailError(response: Promise<Response>) {
         expect((await response).status()).toBeGreaterThanOrEqual(400);
         await expect(this.page.waitForURL('**/login', { timeout: 5000, waitUntil: 'commit' })).rejects.toThrow();
+    }
+
+    async checkRegisterInvalidRepeatPasswordError() {
+        await expect(this.repeatPasswordError).toBeVisible();
+        await expect(this.registerButton).toBeDisabled();
     }
 }

--- a/tests/ui/register/register.spec.ts
+++ b/tests/ui/register/register.spec.ts
@@ -54,7 +54,7 @@ test.describe('Регистрация', () => {
 
     await test.step('Подготовка', () => {
       registerPage = new RegisterPage(page);
-      user = userHelpers.getUserWithTrack(userHelpers.getInvalidStaticUser);
+      user = userHelpers.getUserWithTrack(userHelpers.getInvalidEmailStaticUser);
     })
 
     await test.step('Действие', () => {
@@ -63,6 +63,24 @@ test.describe('Регистрация', () => {
 
     await test.step('Проверка', async () => {
       await registerPage.checkRegisterInvalidEmailError(response);
+    })
+  })
+
+  test('Регистрация c невалидным повтором пароля', async ({ page, userHelpers }) => {
+    let registerPage: RegisterPage;
+    let user: User;
+
+    await test.step('Подготовка', () => {
+      registerPage = new RegisterPage(page);
+      user = userHelpers.getInvalidRepeatPasswordStaticUser();
+    })
+
+    await test.step('Действие', async () => {
+      await registerPage.registerFillFormOnly(user);
+    })
+
+    await test.step('Проверка', async () => {
+      await registerPage.checkRegisterInvalidRepeatPasswordError();
     })
   })
 })

--- a/utils/data/generators/user.generator.ts
+++ b/utils/data/generators/user.generator.ts
@@ -7,10 +7,18 @@ export function getStaticUser(): User {
     }
 }
 
-export function getInvalidStaticUser(): User {
+export function getInvalidEmailStaticUser(): User {
     return {
         email: 'invalid@user',
         password: 'qwe123QWE!@#',
+    }
+}
+
+export function getInvalidRepeatPasswordStaticUser(): User {
+    return {
+        email: 'invalidrepeatpasswordstatic@user.ru',
+        password: 'qwe123QWE!@#',
+        repeatPassword: 'qwe123QWE!@##',
     }
 }
 


### PR DESCRIPTION
- Add optional repeatPassword field to User interface
- Rename getInvalidStaticUser to getInvalidEmailStaticUser for clarity
- Add getInvalidRepeatPasswordStaticUser generator
- Implement repeat password validation in RegisterPage
- Add test case for invalid repeat password scenario