### PR TITLE
feat(auth): add login tests and wrong password user generator

### DIFF
--- a/fixtures/user.fixture.ts
+++ b/fixtures/user.fixture.ts
@@ -1,7 +1,7 @@
-import { test as baseTest } from '@playwright/test';
-import { getExistingUser, getInvalidEmailStaticUser, getStaticUser, getUniqueUser, getInvalidRepeatPasswordStaticUser } from '@utils/data/generators/user.generator';
 import { User } from '@models/user.model';
+import { test as baseTest } from '@playwright/test';
 import { deleteUserByEmail } from '@utils/api/user.api';
+import { getExistingUser, getInvalidEmailStaticUser, getInvalidRepeatPasswordStaticUser, getStaticUser, getUniqueUser, getWrongPasswordStaticUser } from '@utils/data/generators/user.generator';
 
 interface UserFixture {
     userHelpers: UserHelpers
@@ -10,6 +10,7 @@ interface UserFixture {
 interface UserHelpers {
     getStaticUser: () => User;
     getInvalidEmailStaticUser: () => User;
+    getWrongPasswordStaticUser: () => User;
     getInvalidRepeatPasswordStaticUser: () => User;
     getExistingUser: () => User;
     getUniqueUser: () => User;
@@ -24,6 +25,7 @@ export function registerUserFixture(test: typeof baseTest) {
                 users: [],
                 getStaticUser,
                 getInvalidEmailStaticUser,
+                getWrongPasswordStaticUser,
                 getInvalidRepeatPasswordStaticUser,
                 getExistingUser,
                 getUniqueUser,

--- a/pages/login.page.ts
+++ b/pages/login.page.ts
@@ -1,0 +1,69 @@
+import { User } from "@models/user.model";
+import { expect, Locator, Page, Response } from "@playwright/test";
+
+export class LoginPage {
+    private readonly page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    private get mainTitle(): Locator {
+        return this.page.getByRole('heading', { name: 'Login' });
+    }
+
+    private get emailInput(): Locator {
+        return this.page.getByRole('textbox', { name: 'Text field for the login email' })
+    }
+
+    private get passwordInput(): Locator {
+        return this.page.getByRole('textbox', { name: 'Text field for the login password' })
+    }
+
+    private get loginButton(): Locator {
+        return this.page.getByRole('button', { name: 'Login', exact: true })
+    }
+
+    private async go() {
+        await this.page.goto('/#/login');
+    }
+
+    private async checkMainTitle() {
+        await expect(this.mainTitle).toBeVisible();
+    }
+
+    private waitForApiResponse(): Promise<Response> {
+        return this.page.waitForResponse('/rest/user/login');
+    }
+
+    async checkLoginSuccess(response: Promise<Response>) {
+        const body = await (await response).json();
+        expect(body.authentication.token).not.toEqual('');
+        await this.page.waitForURL('/#/search', { waitUntil: 'commit', timeout: 2000 });
+    }
+
+    async checkLoginError(response: Promise<Response>) {
+        expect((await response).status()).toBeGreaterThanOrEqual(400);
+        await expect(this.page.getByText('Invalid email or password.')).toBeVisible();
+        await expect(this.page.getByText('Login')).toBeVisible();
+    }
+
+    async login(user: User): Promise<Response> {
+        await this.go();
+        await this.checkMainTitle();
+        await this.fillForm(user);
+        const response = this.waitForApiResponse();
+        await this.clickLoginButton();
+
+        return response;
+    }
+
+    private async fillForm(user: User) {
+        await this.emailInput.fill(user.email);
+        await this.passwordInput.fill(user.password);
+    }
+
+    private async clickLoginButton() {
+        await this.loginButton.click();
+    }
+}

--- a/tests/ui/login.spec.ts
+++ b/tests/ui/login.spec.ts
@@ -1,0 +1,46 @@
+import { registerUserFixture } from '@fixtures/user.fixture';
+import { User } from '@models/user.model';
+import { LoginPage } from '@pages/login.page';
+import { test as baseTest, Response } from '@playwright/test';
+
+const test = registerUserFixture(baseTest)
+
+test.describe('Вход', () => {
+    test('Успешный вход', async ({ page, userHelpers }) => {
+        let loginPage: LoginPage;
+        let user: User;
+        let response: Promise<Response>;
+
+        await test.step('Подготовка', () => {
+            loginPage = new LoginPage(page);
+            user = userHelpers.getExistingUser();
+        })
+
+        await test.step('Действие', () => {
+            response = loginPage.login(user);
+        })
+
+        await test.step('Проверка', async () => {
+            await loginPage.checkLoginSuccess(response);
+        })
+    })
+
+    test('Неверный пароль', async ({ page, userHelpers }) => {
+        let loginPage: LoginPage;
+        let user: User;
+        let response: Promise<Response>;
+
+        await test.step('Подготовка', () => {
+            loginPage = new LoginPage(page);
+            user = userHelpers.getWrongPasswordStaticUser();
+        })
+
+        await test.step('Действие', () => {
+            response = loginPage.login(user);
+        })
+
+        await test.step('Проверка', async () => {
+            await loginPage.checkLoginError(response);
+        })
+    })
+})

--- a/tests/ui/register.spec.ts
+++ b/tests/ui/register.spec.ts
@@ -1,7 +1,7 @@
-import { test as baseTest, Response } from "@playwright/test"
 import { registerUserFixture } from '@fixtures/user.fixture';
-import { RegisterPage } from '@pages/register.page';
 import { User } from "@models/user.model";
+import { RegisterPage } from '@pages/register.page';
+import { test as baseTest, Response } from "@playwright/test";
 
 const test = registerUserFixture(baseTest);
 

--- a/utils/data/generators/user.generator.ts
+++ b/utils/data/generators/user.generator.ts
@@ -14,6 +14,14 @@ export function getInvalidEmailStaticUser(): User {
     }
 }
 
+export function getWrongPasswordStaticUser(): User {
+    return {
+        email: 'static@user.ru',
+        password: 'qwe123QWE!@#',
+        repeatPassword: 'qwe123QWE!@##',
+    }
+}
+
 export function getInvalidRepeatPasswordStaticUser(): User {
     return {
         email: 'invalidrepeatpasswordstatic@user.ru',


### PR DESCRIPTION
Add login page implementation with tests for successful login and wrong password scenarios Add getWrongPasswordStaticUser generator for test data Move register tests from subfolder to main tests directory